### PR TITLE
Remove PHPDoc getFactory() from FacadeInterfaces

### DIFF
--- a/src/AbstractProduct/AbstractProductFacadeInterface.php
+++ b/src/AbstractProduct/AbstractProductFacadeInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Engineered\AbstractProduct;
 
-/**
- * @method AbstractProductFactory getFactory()
- */
 interface AbstractProductFacadeInterface
 {
     public function get(string $sku): array;

--- a/src/Category/CategoryFacadeInterface.php
+++ b/src/Category/CategoryFacadeInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Engineered\Category;
 
-/**
- * @method CategoryFactory getFactory()
- */
 interface CategoryFacadeInterface
 {
     public function get(int $id): array;

--- a/src/ConcreteProduct/ConcreteProductFacadeInterface.php
+++ b/src/ConcreteProduct/ConcreteProductFacadeInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Engineered\ConcreteProduct;
 
-/**
- * @method ConcreteProductFactory getFactory()
- */
 interface ConcreteProductFacadeInterface
 {
     public function get(string $sku): array;

--- a/src/Customer/CustomerFacadeInterface.php
+++ b/src/Customer/CustomerFacadeInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Engineered\Customer;
 
-/**
- * @method CustomerFactory getFactory()
- */
 interface CustomerFacadeInterface
 {
     public function get(string $bearerToken): array;

--- a/src/Orders/OrdersFacadeInterface.php
+++ b/src/Orders/OrdersFacadeInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Engineered\Orders;
 
-/**
- * @method OrdersFactory getFactory()
- */
 interface OrdersFacadeInterface
 {
     public function getCustomerOrders(string $customerId, string $bearerToken): array;

--- a/src/Wishlist/WishlistFacadeInterface.php
+++ b/src/Wishlist/WishlistFacadeInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Engineered\Wishlist;
 
-/**
- * @method WishlistFactory getFactory()
- */
 interface WishlistFacadeInterface
 {
     public function create(string $name, string $bearerToken): array;


### PR DESCRIPTION
## 📚 Description

The facade interfaces shouldn't know anything about the factory. In fact the factories are `protected`, which means they aren't visible to the outside, just to the child classes.