### PR TITLE
Use addAppConfigKeyValues() in create

### DIFF
--- a/src/SprykerBridge.php
+++ b/src/SprykerBridge.php
@@ -13,11 +13,14 @@ class SprykerBridge
     public static function create(string $glueUrl, string $currency = 'EUR', string $store = 'DE'): SprykerBridgeFacade
     {
         // todo - Add lots of Gacela configuration options here that can be initialised via the "create" function parameters.
+        $configKeyValues = [
+            'GLUE_API_URL' => $glueUrl,
+            'GLUE_CURRENCY' => $currency,
+            'GLUE_STORE' => $store,
+        ];
 
-        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($glueUrl, $currency, $store): void {
-            $config->addAppConfigKeyValue('GLUE_API_URL', $glueUrl);
-            $config->addAppConfigKeyValue('GLUE_CURRENCY', $currency);
-            $config->addAppConfigKeyValue('GLUE_STORE', $store);
+        Gacela::bootstrap(__DIR__, static function (GacelaConfig $config) use ($configKeyValues): void {
+            $config->addAppConfigKeyValues($configKeyValues);
         });
 
         return new SprykerBridgeFacade();


### PR DESCRIPTION
## 📚 Description

Instead of using `addAppConfigKeyValue()` multiple times, and therefore passing multiple variables with `use` to the configurational function, pass one one array with all config key values.