### PR TITLE
Install gacela phpstan extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "phpunit/phpunit": "^9.5",
     "friendsofphp/php-cs-fixer": "^3.13",
     "phpstan/phpstan": "^1.9",
-    "vimeo/psalm": "^5.1"
+    "vimeo/psalm": "^5.1",
+    "gacela-project/phpstan-extension": "^0.1"
   },
   "config": {
     "platform": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+    - vendor/gacela-project/phpstan-extension/extension.neon
+
 parameters:
     level: max
     paths:
@@ -8,3 +11,6 @@ parameters:
     ignoreErrors:
         - '#Cannot cast mixed to *#'
         - '#Method Engineered\\.*Factory::get.* should return .*Interface but returns mixed#'
+
+    gacela:
+        modulesNamespace: Engineered


### PR DESCRIPTION
## 📚 Description

The goal is to install the [Gacela PHPStan Extension](https://github.com/gacela-project/phpstan-extension) and fix all possible errors.