### PR TITLE
Add tests path for phpstan and psalm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "friendsofphp/php-cs-fixer": "^3.13",
     "phpstan/phpstan": "^1.9",
     "vimeo/psalm": "^5.1",
-    "gacela-project/phpstan-extension": "^0.1"
+    "gacela-project/phpstan-extension": "^0.2",
+    "symfony/var-dumper": "^6.0"
   },
   "config": {
     "platform": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ parameters:
     level: max
     paths:
         - %currentWorkingDirectory%/src/
+        - %currentWorkingDirectory%/tests/
     checkGenericClassInNonGenericObjectType: false
     checkMissingIterableValueType: false
 
@@ -14,3 +15,5 @@ parameters:
 
     gacela:
         modulesNamespace: Engineered
+        excludedNamespaces:
+            - EngineeredTests

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="7"
+    errorLevel="5"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
@@ -8,6 +8,7 @@
 >
     <projectFiles>
         <directory name="src" />
+        <directory name="tests" />
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>


### PR DESCRIPTION
## 🔖  Changes

- Add tests directory to phpstan and psalm code static analysers
- Update `phpstan-extension:0.2` 