### PR TITLE
Keep SprykerBridge as singleton

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,7 @@ parameters:
     ignoreErrors:
         - '#Cannot cast mixed to *#'
         - '#Method Engineered\\.*Factory::get.* should return .*Interface but returns mixed#'
+        - '#Method call to a different module is not allowed. Calling:Engineered, RefClasses:Engineered\\SprykerBridge#'
 
     gacela:
         modulesNamespace: Engineered


### PR DESCRIPTION
## 📖  Description

To avoid bootstrapping Gacela every time you use the bridge, we can keep the SprykerBridge as a singleton.

Also, I added `ROOT_DIR` as optional `configKeyValues`.